### PR TITLE
Use 3 or 4 cores, as appropriate, on GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,12 @@ on: [ push, pull_request ]
 permissions:
   contents: read
 
+env:
+  # Currently, GitHub-hosted runners for public repos specify 4 cores, except macOS 14+
+  # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/
+  #     about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  CMAKE_BUILD_PARALLEL_LEVEL: 4 # Default only; overridden where appriopriate, such as on macOS 14+ below
+
 jobs:
   linux:
     runs-on: ubuntu-24.04
@@ -182,6 +188,8 @@ jobs:
 
   mac:
     runs-on: ${{ matrix.os }}
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: ${{ matrix.os == 'macos-13' && 4 || 3 }}
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,6 +9,7 @@ permissions:
   contents: read
 
 env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
   DOXYGEN_VERSION: 1.13.2
 
 jobs:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -8,6 +8,9 @@ on: [ push, pull_request ]
 permissions:
   contents: read
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+
 jobs:
   CodeQL:
     permissions:


### PR DESCRIPTION
That is, use 4 cores everywhere, except only use 3 cores for macOS 14+. See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories